### PR TITLE
Directpeer debug 1

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -44,7 +44,7 @@ var (
 
 	// GossipSubDhi sets the upper bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have more than GossipSubDhi peers, we will select some to prune from the mesh at the next heartbeat.
-	GossipSubDhi = 10
+	GossipSubDhi = 12
 
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are
@@ -59,13 +59,15 @@ var (
 	// our mesh with incoming connections.
 	//
 	// GossipSubDout must be set below GossipSubDlo, and must not exceed GossipSubD / 2.
-	GossipSubDout = 2
+	// GossipSubDout = 2
+	GossipSubDout = 4
 
 	// gossip parameters
 
 	// GossipSubHistoryLength controls the size of the message cache used for gossip.
 	// The message cache will remember messages for GossipSubHistoryLength heartbeats.
-	GossipSubHistoryLength = 5
+	// GossipSubHistoryLength = 5
+	GossipSubHistoryLength = 6
 
 	// GossipSubHistoryGossip controls how many cached message ids we will advertise in
 	// IHAVE gossip messages. When asked for our seen message IDs, we will return
@@ -75,7 +77,8 @@ var (
 	//
 	// GossipSubHistoryGossip must be less than or equal to GossipSubHistoryLength to
 	// avoid a runtime panic.
-	GossipSubHistoryGossip = 3
+	// GossipSubHistoryGossip = 5
+	GossipSubHistoryGossip = 4
 
 	// GossipSubDlazy affects how many peers we will emit gossip to at each heartbeat.
 	// We will send gossip to at least GossipSubDlazy peers outside our mesh. The actual
@@ -141,10 +144,12 @@ var (
 	// with opportunistic grafting. Every GossipSubOpportunisticGraftTicks we will attempt to select some
 	// high-scoring mesh peers to replace lower-scoring ones, if the median score of our mesh peers falls
 	// below a threshold (see https://godoc.org/github.com/libp2p/go-libp2p-pubsub#PeerScoreThresholds).
-	GossipSubOpportunisticGraftTicks uint64 = 60
+	// GossipSubOpportunisticGraftTicks uint64 = 60
+	GossipSubOpportunisticGraftTicks uint64 = 30
 
 	// GossipSubOpportunisticGraftPeers is the number of peers to opportunistically graft.
-	GossipSubOpportunisticGraftPeers = 2
+	// GossipSubOpportunisticGraftPeers = 2
+	GossipSubOpportunisticGraftPeers = 4
 
 	// If a GRAFT comes before GossipSubGraftFloodThreshold has elapsed since the last PRUNE,
 	// then there is an extra score penalty applied to the peer through P7.
@@ -158,7 +163,8 @@ var (
 	GossipSubMaxIHaveLength = 5000
 
 	// GossipSubMaxIHaveMessages is the maximum number of IHAVE messages to accept from a peer within a heartbeat.
-	GossipSubMaxIHaveMessages = 10
+	// GossipSubMaxIHaveMessages = 10
+	GossipSubMaxIHaveMessages = 20
 
 	// Time to wait for a message requested through IWANT following an IHAVE advertisement.
 	// If the message is not received within this window, a broken promise is declared and

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -35,16 +35,16 @@ var (
 	// GossipSubD sets the optimal degree for a GossipSub topic mesh. For example, if GossipSubD == 6,
 	// each peer will want to have about six peers in their mesh for each topic they're subscribed to.
 	// GossipSubD should be set somewhere between GossipSubDlo and GossipSubDhi.
-	GossipSubD = 10
+	GossipSubD = 8
 
 	// GossipSubDlo sets the lower bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have fewer than GossipSubDlo peers, we will attempt to graft some more into the mesh at
 	// the next heartbeat.
-	GossipSubDlo = 8
+	GossipSubDlo = 6
 
 	// GossipSubDhi sets the upper bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have more than GossipSubDhi peers, we will select some to prune from the mesh at the next heartbeat.
-	GossipSubDhi = 16
+	GossipSubDhi = 10
 
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are
@@ -670,9 +670,7 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		if direct {
 			log.Warnf("GRAFT: ignoring request from direct peer %s", p)
 			// this is possibly a bug from non-reciprocal configuration; send a PRUNE
-			// [jianghan] 直连节点不能被削减掉
-			// prune = append(prune, topic)
-			// [/jianghan]
+			prune = append(prune, topic)
 			// but don't PX
 			doPX = false
 			continue
@@ -911,16 +909,20 @@ func (gs *GossipSubRouter) Publish(msg *Message) {
 	} else {
 		// direct peers
 		for p := range gs.direct {
-			_, inTopic := tmap[p]
-			if inTopic {
+			// [jianghan]直连节点不判断，直接广播
+			//_, inTopic := tmap[p]
+			//if inTopic {
+			// [/jianghan]	
 				tosend[p] = struct{}{}
 				
 				//[jianghan]
 				if debug_catch {
 					normal_catch_count++
 				}
-				//[/jianghan]				
-			}
+				//[/jianghan]
+			//[jianghan]
+			//}
+			//[/jianghan]
 		}
 
 		// floodsub peers

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1842,6 +1842,7 @@ func peerMapToList(peers map[peer.ID]struct{}) []peer.ID {
 }
 
 func shufflePeers(peers []peer.ID) {
+	rand.Seed(time.Now().UnixNano())	
 	for i := range peers {
 		j := rand.Intn(i + 1)
 		peers[i], peers[j] = peers[j], peers[i]
@@ -1849,6 +1850,7 @@ func shufflePeers(peers []peer.ID) {
 }
 
 func shufflePeerInfo(peers []*pb.PeerInfo) {
+	rand.Seed(time.Now().UnixNano())
 	for i := range peers {
 		j := rand.Intn(i + 1)
 		peers[i], peers[j] = peers[j], peers[i]
@@ -1856,6 +1858,7 @@ func shufflePeerInfo(peers []*pb.PeerInfo) {
 }
 
 func shuffleStrings(lst []string) {
+	rand.Seed(time.Now().UnixNano())
 	for i := range lst {
 		j := rand.Intn(i + 1)
 		lst[i], lst[j] = lst[j], lst[i]

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -35,16 +35,16 @@ var (
 	// GossipSubD sets the optimal degree for a GossipSub topic mesh. For example, if GossipSubD == 6,
 	// each peer will want to have about six peers in their mesh for each topic they're subscribed to.
 	// GossipSubD should be set somewhere between GossipSubDlo and GossipSubDhi.
-	GossipSubD = 10
+	GossipSubD = 18
 
 	// GossipSubDlo sets the lower bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have fewer than GossipSubDlo peers, we will attempt to graft some more into the mesh at
 	// the next heartbeat.
-	GossipSubDlo = 8
+	GossipSubDlo = 12
 
 	// GossipSubDhi sets the upper bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have more than GossipSubDhi peers, we will select some to prune from the mesh at the next heartbeat.
-	GossipSubDhi = 16
+	GossipSubDhi = 24
 
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -670,7 +670,9 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		if direct {
 			log.Warnf("GRAFT: ignoring request from direct peer %s", p)
 			// this is possibly a bug from non-reciprocal configuration; send a PRUNE
-			prune = append(prune, topic)
+			// [jianghan] 直连节点不能被削减掉
+			// prune = append(prune, topic)
+			// [/jianghan]
 			// but don't PX
 			doPX = false
 			continue

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -964,7 +964,7 @@ func (gs *GossipSubRouter) Publish(msg *Message) {
 	
 	//[jianghan]
 	if debug_catch {
-		log.Infof("[publish directpeer] flood_catch_count = %d , normal_catch_count = %d, topic = %s", flood_catch_count, normal_catch_count, topic)
+		log.Infof("[**publish directpeer**] flood_catch_count = %d , normal_catch_count = %d, topic = %s", flood_catch_count, normal_catch_count, topic)
 	}
 	//[/jianghan]	
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -49,7 +49,9 @@ var (
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are
 	// chosen randomly.
-	GossipSubDscore = 4
+	// 将它改小，让更多peer能够参与轮换，而不是固定几个通讯点
+	// GossipSubDscore = 4
+	GossipSubDscore = 0	
 
 	// GossipSubDout sets the quota for the number of outbound connections to maintain in a topic mesh.
 	// When the mesh is pruned due to over subscription, we make sure that we have outbound connections

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -35,16 +35,16 @@ var (
 	// GossipSubD sets the optimal degree for a GossipSub topic mesh. For example, if GossipSubD == 6,
 	// each peer will want to have about six peers in their mesh for each topic they're subscribed to.
 	// GossipSubD should be set somewhere between GossipSubDlo and GossipSubDhi.
-	GossipSubD = 18
+	GossipSubD = 10
 
 	// GossipSubDlo sets the lower bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have fewer than GossipSubDlo peers, we will attempt to graft some more into the mesh at
 	// the next heartbeat.
-	GossipSubDlo = 12
+	GossipSubDlo = 8
 
 	// GossipSubDhi sets the upper bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have more than GossipSubDhi peers, we will select some to prune from the mesh at the next heartbeat.
-	GossipSubDhi = 24
+	GossipSubDhi = 16
 
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -35,16 +35,16 @@ var (
 	// GossipSubD sets the optimal degree for a GossipSub topic mesh. For example, if GossipSubD == 6,
 	// each peer will want to have about six peers in their mesh for each topic they're subscribed to.
 	// GossipSubD should be set somewhere between GossipSubDlo and GossipSubDhi.
-	GossipSubD = 6
+	GossipSubD = 10
 
 	// GossipSubDlo sets the lower bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have fewer than GossipSubDlo peers, we will attempt to graft some more into the mesh at
 	// the next heartbeat.
-	GossipSubDlo = 5
+	GossipSubDlo = 8
 
 	// GossipSubDhi sets the upper bound on the number of peers we keep in a GossipSub topic mesh.
 	// If we have more than GossipSubDhi peers, we will select some to prune from the mesh at the next heartbeat.
-	GossipSubDhi = 12
+	GossipSubDhi = 16
 
 	// GossipSubDscore affects how peers are selected when pruning a mesh due to over subscription.
 	// At least GossipSubDscore of the retained peers will be high-scoring, while the remainder are
@@ -130,7 +130,7 @@ var (
 
 	// GossipSubDirectConnectTicks is the number of heartbeat ticks for attempting to reconnect direct peers
 	// that are not currently connected.
-	GossipSubDirectConnectTicks uint64 = 300
+	GossipSubDirectConnectTicks uint64 = 180
 
 	// GossipSubDirectConnectInitialDelay is the initial delay before opening connections to direct peers
 	GossipSubDirectConnectInitialDelay = time.Second


### PR DESCRIPTION
direct peer 实测会被prune出 topic mesh ，所以 publish 的时候需要去掉有关 topic 的判断，否则块广播会有一些 direct peer 收不到